### PR TITLE
Fix code scanning alert no. 21: Overly permissive regular expression range

### DIFF
--- a/packages/static-data/scripts/characters.ts
+++ b/packages/static-data/scripts/characters.ts
@@ -136,7 +136,7 @@ export async function collateCharacters(
     )!.cardPrefabName;
     const cardFace = `UI_${cardPrefabName}`;
     const icon = cardFace.replace(
-      /CardFace_Char_([a-zA-Z]+)_([a-zA-z]+)$/,
+      /CardFace_Char_([a-zA-Z]+)_([a-zA-Z]+)$/,
       (match, p1, p2) => {
         return `Char_${p1}Icon_${CARDFACE_TO_AVATAR_MAP[p2] ?? p2}`;
       },

--- a/packages/static-data/scripts/hakushin/index.ts
+++ b/packages/static-data/scripts/hakushin/index.ts
@@ -171,7 +171,7 @@ const collateCharacter = async (
 
   const cardFace: string = rawJson.Icon;
   const icon = cardFace.replace(
-    /CardFace_Char_([a-zA-Z]+)_([a-zA-z]+)$/,
+    /CardFace_Char_([a-zA-Z]+)_([a-zA-Z]+)$/,
     (match, p1, p2) => {
       return `Char_${p1}Icon_${p2}`;
     },


### PR DESCRIPTION
Fixes https://github.com/genius-invokation/genius-invokation/security/code-scanning/20
Fixes https://github.com/genius-invokation/genius-invokation/security/code-scanning/21

To fix the problem, we need to correct the overly permissive regular expression range by replacing `A-z` with `A-Z`. This will ensure that the regular expression only matches uppercase and lowercase letters as intended.

- Locate the regular expression on line 174 in the file `packages/static-data/scripts/hakushin/index.ts`.
- Replace the range `A-z` with `A-Z` to avoid matching unintended characters.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
