### PR TITLE
fix(core): remove equipment do not trigger onDispose

### DIFF
--- a/packages/core/src/builder/context/character.ts
+++ b/packages/core/src/builder/context/character.ts
@@ -237,6 +237,7 @@ export class Character<Meta extends ContextMetaBase> extends CharacterBase {
     }
     this.skillContext.createEntity("equipment", equipment, this._area, opt);
   }
+  /** 不触发 onDispose */ 
   removeArtifact(): EntityState | null {
     const entity = this.state.entities.find((v) =>
       v.definition.tags.includes("artifact"),
@@ -244,9 +245,10 @@ export class Character<Meta extends ContextMetaBase> extends CharacterBase {
     if (!entity) {
       return null;
     }
-    this.skillContext.dispose(entity);
+    this.skillContext.dispose(entity, { noTriggerEvent: true });
     return entity;
   }
+  /** 不触发 onDispose */ 
   removeWeapon(): EntityState | null {
     const entity = this.state.entities.find((v) =>
       v.definition.tags.includes("weapon"),
@@ -254,7 +256,7 @@ export class Character<Meta extends ContextMetaBase> extends CharacterBase {
     if (!entity) {
       return null;
     }
-    this.skillContext.dispose(entity);
+    this.skillContext.dispose(entity, { noTriggerEvent: true });
     return entity;
   }
   loseEnergy(count = 1): number {


### PR DESCRIPTION
官方实现中，remove equipment 只会在琴音和藏锋两张“返回手牌”中使用，实际调用的是 transferEntity 当然不会触发 onDispose。为了维护底层架构，目前修改手牌-实体的转移工作量较大，暂时先这样处理。