### PR TITLE
fix(core): change `useSkill` event condition

### DIFF
--- a/packages/core/src/builder/skill.ts
+++ b/packages/core/src/builder/skill.ts
@@ -422,28 +422,21 @@ const detailedEventDictionary = {
     return (
       checkRelative(e.onTimeState, e.callerArea, r) &&
       isCharacterInitiativeSkill(e.skill) &&
-      !e.skill.prepared
+      !e.skill.definition.initiativeSkillConfig.hidden
     );
   }),
   useTechnique: defineDescriptor("onUseSkill", (c, e, r) => {
     return (
       checkRelative(e.onTimeState, e.callerArea, r) &&
       e.isSkillType("technique") &&
-      !e.skill.prepared
+      !e.skill.definition.initiativeSkillConfig.hidden
     );
   }),
   useSkillOrTechnique: defineDescriptor("onUseSkill", (c, e, r) => {
     return (
       checkRelative(e.onTimeState, e.callerArea, r) &&
       isCharacterInitiativeSkill(e.skill, true) &&
-      !e.skill.prepared
-    );
-  }),
-  usePreparedSkill: defineDescriptor("onUseSkill", (c, e, r) => {
-    return (
-      checkRelative(e.onTimeState, e.callerArea, r) &&
-      isCharacterInitiativeSkill(e.skill) &&
-      e.skill.prepared
+      !e.skill.definition.initiativeSkillConfig.hidden
     );
   }),
   declareEnd: defineDescriptor("onAction", (c, e, r) => {


### PR DESCRIPTION
过去我们认为“准备技能”不触发“使用技能后”，但实际更合理的定义为“只能通过准备技能使用的技能”，即那些不能通过主动使用调用的技能，才不触发“使用技能后”