### PR TITLE
feat(web-ui-core): better alert and dice selection

### DIFF
--- a/packages/web-ui-core/src/action.ts
+++ b/packages/web-ui-core/src/action.ts
@@ -408,8 +408,8 @@ function diceReqText(
     const name =
       (ctx.assetsManager.getNameSync(-300 - shifted) ?? "")
         .replace("无色", "任意")
-        .replace("相同", "") + "骰";
-    const style = `color: var(--c-${DICE_COLOR[type]});`;
+        .replace("相同", count === 1 ? "" : "相同") + "骰";
+    const style = (type >=1 && type<=7) ? `color: var(--c-${DICE_COLOR[type]});` : "";
     return `${count}个<span style="${style}">${name}</span>`;
   });
   return `请支付${diceText.join("和")}`;

--- a/packages/web-ui-core/src/action.ts
+++ b/packages/web-ui-core/src/action.ts
@@ -409,7 +409,8 @@ function diceReqText(
       (ctx.assetsManager.getNameSync(-300 - shifted) ?? "")
         .replace("无色", "任意")
         .replace("相同", count === 1 ? "" : "相同") + "骰";
-    const style = (type >=1 && type<=7) ? `color: var(--c-${DICE_COLOR[type]});` : "";
+    const style =
+      type >= 1 && type <= 7 ? `color: var(--c-${DICE_COLOR[type]});` : "";
     return `${count}个<span style="${style}">${name}</span>`;
   });
   return `请支付${diceText.join("和")}`;
@@ -881,10 +882,11 @@ function createSwitchActiveActionState(
   root: ActionState,
   ctx: CreateSwitchActiveActionStateContext,
 ): void {
+  const ok = ctx.action.validity === ActionValidity.VALID;
   const INNER_SWITCH_ACTIVE_BUTTON: ClickSwitchActiveButtonActionStep = {
     type: "clickSwitchActiveButton",
     targetCharacterId: ctx.action.value.characterId,
-    isDisabled: false,
+    isDisabled: !ok,
     isFocused: true,
   };
   const OUTER_SWITCH_ACTIVE_BUTTON: ClickSwitchActiveButtonActionStep = {
@@ -938,7 +940,7 @@ function createSwitchActiveActionState(
         const diceReq = new Map(
           realCost.map(({ type, count }) => [type as DiceType, count]),
         );
-        if (checkDice(diceReq, dice)) {
+        if (ok && checkDice(diceReq, dice)) {
           return {
             type: "actionCommitted",
             chosenActionIndex: ctx.index,
@@ -950,7 +952,8 @@ function createSwitchActiveActionState(
             newState: {
               ...innerState,
               autoSelectedDice: null,
-              alertText: diceReqText(diceReq, ctx),
+              alertText:
+                validityText(ctx.action.validity) ?? diceReqText(diceReq, ctx),
             },
           };
         }
@@ -1077,9 +1080,6 @@ export function createActionState(
         break;
       }
       case "switchActive": {
-        if (validity !== ActionValidity.VALID) {
-          continue;
-        }
         realCosts.switchActive.set(action.value.characterId, requiredCost);
         createSwitchActiveActionState(root, {
           assetsManager,

--- a/packages/web-ui-core/src/action.ts
+++ b/packages/web-ui-core/src/action.ts
@@ -30,6 +30,7 @@ import {
   type SwitchActiveAction,
 } from "@gi-tcg/typings";
 import type { DicePanelState } from "./components/DicePanel";
+import { DICE_COLOR } from "./components/Dice";
 import { checkDice } from "@gi-tcg/utils";
 import type { SkillRawData, ActionCardRawData } from "@gi-tcg/static-data";
 import type { AssetsManager } from "@gi-tcg/assets-manager";
@@ -397,6 +398,20 @@ interface CreatePlayCardActionStateContext {
   index: number;
 }
 
+function diceReqText(
+  diceReq: Map<DiceType, number>,
+  ctx: { assetsManager: any },
+) { 
+  const diceName = Array.from(diceReq.entries())
+    .map(([type, count]) => {
+      const shifted = (type + 8) % 9 + 1;
+      let name = ctx.assetsManager.getNameSync(-300 - shifted);
+      name = name.replace("无色", "任意");
+      return `${count}个[[color:${DICE_COLOR[type]}]]${name}[[/color]]`;
+    });    
+  return `请支付${diceName.join("和").replace("1个[[color:omni]]相同元素[[/color]]", "1个元素骰")}`;
+}
+
 function createPlayCardActionState(
   root: ActionState,
   ctx: CreatePlayCardActionStateContext,
@@ -490,7 +505,7 @@ function createPlayCardActionState(
             newState: {
               ...resultState,
               autoSelectedDice: null,
-              alertText: "骰子不符合要求",
+              alertText: diceReqText(diceReq, ctx),
             },
           };
         }
@@ -596,7 +611,7 @@ function createMultiStepState<T>(
                 type: "newState",
                 newState: {
                   ...resultState,
-                  alertText: "骰子不符合要求",
+                  alertText: diceReqText(diceReq, ctx),
                 },
               };
             }
@@ -777,7 +792,7 @@ function createUseSkillActionState(
             newState: {
               ...resultState,
               autoSelectedDice: null,
-              alertText: validityText(ctx.action.validity) ?? "骰子不符合要求",
+              alertText: validityText(ctx.action.validity) ?? diceReqText(diceReq, ctx),
             },
           };
         }
@@ -925,7 +940,7 @@ function createSwitchActiveActionState(
             newState: {
               ...innerState,
               autoSelectedDice: null,
-              alertText: "骰子不符合要求",
+              alertText: diceReqText(diceReq, ctx),
             },
           };
         }

--- a/packages/web-ui-core/src/components/Alert.tsx
+++ b/packages/web-ui-core/src/components/Alert.tsx
@@ -1,0 +1,49 @@
+// Copyright (C) 2025 Guyutongxue
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+export interface AlertProps {
+  class?: string;
+  text?: string;
+}
+
+function renderAlertText(text: string) {
+  const parts = text.split(/\[\[\/?color(?::(.*?))?\]\]/g);
+  return parts.map((part, i) => {
+    if (i % 2 === 1) {
+      const color = part;
+      const content = parts[i + 1];
+      parts[i + 1] = '';
+      const style =
+        color === 'void' || color === 'omni'
+          ? { color: 'inherit' }
+          : { color: `var(--c-${color})` };
+      return <span style={style}>{content}</span>;
+    }
+    return part;
+  });
+}
+
+export function Alert(props: AlertProps) {
+  return (
+    <div
+      class={`w-84 h-16 pointer-events-none flex flex-row justify-center font-bold items-center bg-#786049 border-#bea678 b-3 text-white rounded-1.5 text-4.5 color-#ede4d8 opacity-100 visible animate-[hideAfter_4000ms_forwards] pointer-events-none contain-[layout_paint] ${
+        props.class ?? ""
+      }`}
+      bool:data-shown={props.text}
+    >
+      {props.text ? renderAlertText(props.text) : undefined}
+    </div>
+  );
+}

--- a/packages/web-ui-core/src/components/CharacterArea.tsx
+++ b/packages/web-ui-core/src/components/CharacterArea.tsx
@@ -361,7 +361,7 @@ export function CharacterArea(props: CharacterAreaProps) {
         <CharacterTagMasks tags={data().tags} />
       </div>
       <Show when={props.active}>
-        <StatusGroup class="h-6 w-20" statuses={props.combatStatus} />
+        <StatusGroup class="h-6 w-20 z-10" statuses={props.combatStatus} />
       </Show>
     </div>
   );

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -1695,16 +1695,6 @@ export function Chessboard(props: ChessboardProps) {
               class="absolute top-[calc(50%+2rem)] bottom-2 left-2"
               {...playerInfoPropsOf(localProps.who)}
             />
-            <SkillButtonGroup
-              class="absolute bottom-3 right-2 scale-120% translate-x--10% translate-y--10%"
-              skills={mySkills()}
-              switchActiveButton={switchActiveStep() ?? null}
-              switchActiveCost={
-                localProps.actionState?.realCosts.switchActive ?? null
-              }
-              onClick={onSkillClick}
-              shown={showSkillButtons()}
-            />
             <DicePanel
               dice={myDice()}
               selectedDice={selectedDice()}
@@ -1714,6 +1704,16 @@ export function Chessboard(props: ChessboardProps) {
               onSelectDice={setSelectedDice}
               state={dicePanelState()}
               onStateChange={setDicePanelState}
+            />
+            <SkillButtonGroup
+              class="absolute bottom-3 right-2 scale-120% translate-x--10% translate-y--10%"
+              skills={mySkills()}
+              switchActiveButton={switchActiveStep() ?? null}
+              switchActiveCost={
+                localProps.actionState?.realCosts.switchActive ?? null
+              }
+              onClick={onSkillClick}
+              shown={showSkillButtons()}
             />
           </Show>
           <ConfirmButton

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -123,6 +123,7 @@ import { SwitchHandsView } from "./SwitchHandsView";
 import { MutationViewer } from "./MutationViewer";
 import { CurrentTurnHint } from "./CurrentTurnHint";
 import { SpecialViewToggleButton } from "./SpecialViewToggleButton";
+import { Alert } from "./Alert";
 
 export type CardArea = "myPile" | "oppPile" | "myHand" | "oppHand";
 
@@ -1175,7 +1176,8 @@ export function Chessboard(props: ChessboardProps) {
             setSelectedDice(selectingDice);
           }
           if (actionState.alertText) {
-            alert(actionState.alertText);
+            // alert(actionState.alertText);
+            setShowAlert(true);
           }
           setDicePanelState(actionState.dicePanel);
         } else if (prevActionState) {
@@ -1213,6 +1215,16 @@ export function Chessboard(props: ChessboardProps) {
     }, 500);
     setShowCardHint(area, timeout);
   };
+
+  const [showAlert, setShowAlert] = createSignal(false);
+  createEffect(() => {
+    if (showAlert()) {
+      const timer = setTimeout(() => {
+        setShowAlert(false);
+      }, 4000);
+      return () => clearTimeout(timer);
+    }
+  });
 
   const [showDeclareEndButton, setShowDeclareEndButton] = createSignal(false);
   const declareEndMarkerProps = createMemo<DeclareEndMarkerProps>(() => {
@@ -1554,7 +1566,7 @@ export function Chessboard(props: ChessboardProps) {
   };
 
   const onSkillClick = (sk: SkillInfo) => {
-    setShowDeclareEndButton(false)
+    setShowDeclareEndButton(false);
     if (sk.id === "switchActive") {
       const step = switchActiveStep();
       if (step) {
@@ -1698,12 +1710,14 @@ export function Chessboard(props: ChessboardProps) {
             <DicePanel
               dice={myDice()}
               selectedDice={selectedDice()}
+              diceRequiredNumber={localProps.actionState?.autoSelectedDice?.length ?? 0}
               disabledDiceTypes={
                 localProps.actionState?.disabledDiceTypes ?? []
               }
               onSelectDice={setSelectedDice}
               state={dicePanelState()}
               onStateChange={setDicePanelState}
+              onClick={() => {setShowAlert(false);}}
             />
             <SkillButtonGroup
               class="absolute bottom-3 right-2 scale-120% translate-x--10% translate-y--10%"
@@ -1736,6 +1750,12 @@ export function Chessboard(props: ChessboardProps) {
             {(data) => (
               <NotificationBox opp={data.who !== localProps.who} data={data} />
             )}
+          </Show>
+          <Show when={showAlert() && localProps.actionState?.alertText}>
+            <Alert
+              class="absolute left-50% top-50% translate-x--50% translate-y--50%"
+              text={localProps.actionState?.alertText}
+            />
           </Show>
           <Show when={localProps.data.playingCard} keyed>
             {(data) => (

--- a/packages/web-ui-core/src/components/DicePanel.tsx
+++ b/packages/web-ui-core/src/components/DicePanel.tsx
@@ -24,24 +24,22 @@ export interface DicePanelProps {
   dice: DiceType[];
   disabledDiceTypes: DiceType[];
   selectedDice: boolean[];
-  diceRequiredNumber: number;
+  maxSelectedCount: number | null;
   onSelectDice: (selectedDice: boolean[]) => void;
   state: DicePanelState;
   onStateChange: (state: DicePanelState) => void;
-  onClick: (e: MouseEvent) => void;
 }
 
 export function DicePanel(props: DicePanelProps) {
   const toggleDice = (dice: DiceType, index: number) => {
+    console.log(props.maxSelectedCount);
     if (props.disabledDiceTypes.includes(dice)) {
       return;
     }
     const rawSelectedDice = props.selectedDice;
     const selectedDice = Array.from(props.dice, (_, i) => !!rawSelectedDice[i]);
     const selectedCount = selectedDice.filter(Boolean).length;
-    if (props.diceRequiredNumber === 0) {
-      selectedDice[index] = !selectedDice[index];
-    } else if (selectedCount < props.diceRequiredNumber) {
+    if (!props.maxSelectedCount || selectedCount < props.maxSelectedCount) {
       selectedDice[index] = !selectedDice[index];
     } else {
       if (selectedDice[index]) {
@@ -63,9 +61,8 @@ export function DicePanel(props: DicePanelProps) {
   return (
     <>
       <div
-        class="absolute right--40 data-[state=visible]:right--4 data-[state=wrapped]:right--4 top-0 bottom-0 pr-4 gap-2 w-0 data-[state=visible]:w-40 data-[state=wrapped]:w-18 h-full flex flex-row items-center transition-right dice-panel data-[state=hidden]:pr-0"
+        class="absolute right--40 data-[state=visible]:right--4 data-[state=wrapped]:right--4 top-0 bottom-0 pr-4 gap-2 w-0 data-[state=visible]:w-40 data-[state=wrapped]:w-18 h-full flex flex-row items-center transition-right dice-panel data-[state=hidden]:pr-0 select-none"
         data-state={props.state}
-        onClick={(e) => {props.onClick(e);}}
       >
         <div
           class="text-#e7d090 h-60 ml-1 flex items-center select-none cursor-pointer"
@@ -102,7 +99,7 @@ export function DicePanel(props: DicePanelProps) {
         class="absolute right-0 top-0 bottom-0 opacity-0 pointer-events-none data-[shown]:opacity-100 transition-opacity"
         bool:data-shown={props.state !== "visible"}
       >
-        <div class="pointer-events-auto m-2 flex flex-col select-none gap-2 items-center">
+        <div class=" m-2 flex flex-col select-none gap-2 items-center">
           <WithDelicateUi
             assetId={"UI_Gcg_DiceL_Count_03"}
             fallback={

--- a/packages/web-ui-core/src/components/DicePanel.tsx
+++ b/packages/web-ui-core/src/components/DicePanel.tsx
@@ -24,9 +24,11 @@ export interface DicePanelProps {
   dice: DiceType[];
   disabledDiceTypes: DiceType[];
   selectedDice: boolean[];
+  diceRequiredNumber: number;
   onSelectDice: (selectedDice: boolean[]) => void;
   state: DicePanelState;
   onStateChange: (state: DicePanelState) => void;
+  onClick: (e: MouseEvent) => void;
 }
 
 export function DicePanel(props: DicePanelProps) {
@@ -36,7 +38,19 @@ export function DicePanel(props: DicePanelProps) {
     }
     const rawSelectedDice = props.selectedDice;
     const selectedDice = Array.from(props.dice, (_, i) => !!rawSelectedDice[i]);
-    selectedDice[index] = !selectedDice[index];
+    const selectedCount = selectedDice.filter(Boolean).length;
+    if (props.diceRequiredNumber === 0) {
+      selectedDice[index] = !selectedDice[index];
+    } else if (selectedCount < props.diceRequiredNumber) {
+      selectedDice[index] = !selectedDice[index];
+    } else {
+      if (selectedDice[index]) {
+        selectedDice[index] = false;
+      } else {
+        selectedDice.fill(false);
+        selectedDice[index] = true;
+      }
+    }
     props.onSelectDice(selectedDice);
   };
   const toggleState = () => {
@@ -51,6 +65,7 @@ export function DicePanel(props: DicePanelProps) {
       <div
         class="absolute right--40 data-[state=visible]:right--4 data-[state=wrapped]:right--4 top-0 bottom-0 pr-4 gap-2 w-0 data-[state=visible]:w-40 data-[state=wrapped]:w-18 h-full flex flex-row items-center transition-right dice-panel data-[state=hidden]:pr-0"
         data-state={props.state}
+        onClick={(e) => {props.onClick(e);}}
       >
         <div
           class="text-#e7d090 h-60 ml-1 flex items-center select-none cursor-pointer"

--- a/packages/web-ui-core/src/style.css
+++ b/packages/web-ui-core/src/style.css
@@ -422,17 +422,14 @@
   }
 }
 
-@keyframes hideAfter {
+@keyframes alert-auto-hide {
   0% {
-    visibility: visible;
     opacity: 1;
   }
   90% {
-    visibility: visible;
     opacity: 1;
   }
   100% {
-    visibility: hidden;
     opacity: 0;
   }
 }

--- a/packages/web-ui-core/src/style.css
+++ b/packages/web-ui-core/src/style.css
@@ -146,15 +146,11 @@
 
   .current-turn-hint[data-opp="false"] {
     --fg-color: #644d39;
-    --inner-background-color: #786049;
-    --inner-border-color: #bea678;
     --bg-color: #d9b48d;
   }
 
   .current-turn-hint[data-opp="true"] {
     --fg-color: #3f4957;
-    --inner-background-color: #485569;
-    --inner-border-color: #899dc6;
     --bg-color: #7e98cb;
   }
 
@@ -422,6 +418,21 @@
 
   100% {
     transform: scale(1.375);
+    opacity: 0;
+  }
+}
+
+@keyframes hideAfter {
+  0% {
+    visibility: visible;
+    opacity: 1;
+  }
+  90% {
+    visibility: visible;
+    opacity: 1;
+  }
+  100% {
+    visibility: hidden;
     opacity: 0;
   }
 }


### PR DESCRIPTION
通过向dicepanel内传递autoselect.len，在toggleDice函数内判断数量，实现超出重置
在action.ts内增加一个函数翻译骰子需求，使警告信息更详细
Alert模块，渲染警告框，以及富文本染色
chessboard内部，控制警告信息的显示，首先警告信息要存在，另一个信号用于控制重复显示，以及在点击新的骰子之后立即隐藏警告

<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
