### PR TITLE
feat(web-ui): add MessageBox Component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -377,8 +377,8 @@
   },
   "overrides": {
     "babel-plugin-jsx-dom-expressions": "0.39.6",
-    "caniuse-lite": "1.0.30001690",
     "esbuild": "0.19.11",
+    "caniuse-lite": "1.0.30001690",
   },
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -124,6 +124,7 @@ import { MutationViewer } from "./MutationViewer";
 import { CurrentTurnHint } from "./CurrentTurnHint";
 import { SpecialViewToggleButton } from "./SpecialViewToggleButton";
 import { createAlert } from "./Alert";
+import { createMessageBox } from "./MessageBox";
 
 export type CardArea = "myPile" | "oppPile" | "myHand" | "oppHand";
 
@@ -1219,6 +1220,7 @@ export function Chessboard(props: ChessboardProps) {
   };
 
   const [{ show: showAlert, hide: hideAlert }, Alert] = createAlert();
+  const [{ show: showMessageBox }, MessageBox] = createMessageBox();
 
   const [showDeclareEndButton, setShowDeclareEndButton] = createSignal(false);
   const declareEndMarkerProps = createMemo<DeclareEndMarkerProps>(() => {
@@ -1761,9 +1763,7 @@ export function Chessboard(props: ChessboardProps) {
               class="absolute right-2.3 top-2.5 h-8 w-8 flex items-center justify-center rounded-full b-red-800 b-1 bg-red-500 hover:bg-red-600 active:bg-red-600 text-white transition-colors line-height-none cursor-pointer"
               title="放弃对局"
               onClick={() => {
-                if (confirm("确定放弃对局吗？")) {
-                  localProps.onGiveUp?.();
-                }
+                showMessageBox({message: "确定放弃对局吗？", onConfirm: () => (localProps.onGiveUp?.())});
               }}
             >
               &#10005;
@@ -1857,6 +1857,7 @@ export function Chessboard(props: ChessboardProps) {
           )}
         </Show>
         {/* game end */}
+        <MessageBox />
         <Show when={localProps.data.state.phase === PbPhaseType.GAME_END}>
           <div class="absolute inset-0 bg-black/60 flex items-center justify-center font-bold text-4xl text-white">
             {localProps.data.state.winner === localProps.who ? "胜利" : "失败"}

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -124,7 +124,7 @@ import { MutationViewer } from "./MutationViewer";
 import { CurrentTurnHint } from "./CurrentTurnHint";
 import { SpecialViewToggleButton } from "./SpecialViewToggleButton";
 import { createAlert } from "./Alert";
-import { createMessageBox } from "./MessageBox";
+import { messageBox, mountMessageBox } from "./MessageBox";
 
 export type CardArea = "myPile" | "oppPile" | "myHand" | "oppHand";
 
@@ -562,6 +562,8 @@ interface ChessboardChildren {
   cardCountHints: CardCountHintInfo[];
   tunningArea: TunningAreaInfo | null;
 }
+
+mountMessageBox();
 
 function rerenderChildren(opt: {
   who: 0 | 1;
@@ -1220,7 +1222,6 @@ export function Chessboard(props: ChessboardProps) {
   };
 
   const [{ show: showAlert, hide: hideAlert }, Alert] = createAlert();
-  const [{ show: showMessageBox }, MessageBox] = createMessageBox();
 
   const [showDeclareEndButton, setShowDeclareEndButton] = createSignal(false);
   const declareEndMarkerProps = createMemo<DeclareEndMarkerProps>(() => {
@@ -1763,7 +1764,7 @@ export function Chessboard(props: ChessboardProps) {
               class="absolute right-2.3 top-2.5 h-8 w-8 flex items-center justify-center rounded-full b-red-800 b-1 bg-red-500 hover:bg-red-600 active:bg-red-600 text-white transition-colors line-height-none cursor-pointer"
               title="放弃对局"
               onClick={() => {
-                showMessageBox({message: "确定放弃对局吗？", onConfirm: () => (localProps.onGiveUp?.())});
+                messageBox("确定放弃对局吗？", () => {localProps.onGiveUp?.();});
               }}
             >
               &#10005;
@@ -1857,7 +1858,6 @@ export function Chessboard(props: ChessboardProps) {
           )}
         </Show>
         {/* game end */}
-        <MessageBox />
         <Show when={localProps.data.state.phase === PbPhaseType.GAME_END}>
           <div class="absolute inset-0 bg-black/60 flex items-center justify-center font-bold text-4xl text-white">
             {localProps.data.state.winner === localProps.who ? "胜利" : "失败"}

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -124,7 +124,7 @@ import { MutationViewer } from "./MutationViewer";
 import { CurrentTurnHint } from "./CurrentTurnHint";
 import { SpecialViewToggleButton } from "./SpecialViewToggleButton";
 import { createAlert } from "./Alert";
-import { messageBox, mountMessageBox } from "./MessageBox";
+import { createMessageBox } from "./MessageBox";
 
 export type CardArea = "myPile" | "oppPile" | "myHand" | "oppHand";
 
@@ -562,8 +562,6 @@ interface ChessboardChildren {
   cardCountHints: CardCountHintInfo[];
   tunningArea: TunningAreaInfo | null;
 }
-
-mountMessageBox();
 
 function rerenderChildren(opt: {
   who: 0 | 1;
@@ -1222,6 +1220,7 @@ export function Chessboard(props: ChessboardProps) {
   };
 
   const [{ show: showAlert, hide: hideAlert }, Alert] = createAlert();
+  const [{ confirm }, MessageBox] = createMessageBox();
 
   const [showDeclareEndButton, setShowDeclareEndButton] = createSignal(false);
   const declareEndMarkerProps = createMemo<DeclareEndMarkerProps>(() => {
@@ -1763,8 +1762,10 @@ export function Chessboard(props: ChessboardProps) {
             <button
               class="absolute right-2.3 top-2.5 h-8 w-8 flex items-center justify-center rounded-full b-red-800 b-1 bg-red-500 hover:bg-red-600 active:bg-red-600 text-white transition-colors line-height-none cursor-pointer"
               title="放弃对局"
-              onClick={() => {
-                messageBox("确定放弃对局吗？", () => {localProps.onGiveUp?.();});
+              onClick={async () => {
+                if (await confirm("确定放弃对局吗？")) {
+                  localProps.onGiveUp?.();
+                }
               }}
             >
               &#10005;
@@ -1840,6 +1841,7 @@ export function Chessboard(props: ChessboardProps) {
           </Show>
         </AspectRatioContainer>
         <Alert />
+        <MessageBox />
         <Show when={localProps.doingRpc && localProps.timer}>
           {(timer) => (
             <div

--- a/packages/web-ui-core/src/components/MessageBox.tsx
+++ b/packages/web-ui-core/src/components/MessageBox.tsx
@@ -1,0 +1,99 @@
+// Copyright (C) 2024-2025 Guyutongxue
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createEffect, createSignal, Show, type Component } from "solid-js";
+
+interface MessageBoxOptions {
+  message: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+}
+
+export interface MessageBoxController {
+  show: (options: MessageBoxOptions) => void;
+}
+
+export const createMessageBox = (): [
+  controller: MessageBoxController,
+  component: Component,
+] => {
+  const [shown, setShown] = createSignal(false);
+  const [message, setMessage] = createSignal<string>("");
+  const [onConfirm, setOnConfirm] = createSignal<() => void>(() => {});
+  const [onCancel, setOnCancel] = createSignal<() => void | undefined>();
+
+  const show = (options: MessageBoxOptions) => {
+    setMessage(options.message);
+    setOnConfirm(() => () => {
+      options.onConfirm();
+      setShown(false);
+    });
+    setOnCancel(() => () => {
+      options.onCancel?.();
+      setShown(false);
+    });
+    setShown(true);
+  };
+
+  return [
+    { show },
+    () => (
+      <MessageBox
+        shown={shown()}
+        message={message()}
+        onConfirm={onConfirm()}
+        onCancel={onCancel()}
+      />
+    ),
+  ];
+};
+
+interface MessageBoxProps {
+  shown: boolean;
+  class?: string;
+  message: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+}
+
+function MessageBox(props: MessageBoxProps) {
+  return (
+    <Show when={props.shown}>
+      <div class="absolute inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div class="bg-#ebdab7 p-4 rounded-3 shadow-lg w-96 h-48 border-#735a3f b-2">
+          <p class="h-24 font-size-6 font-bold mt-4 text-center">{props.message}</p>
+          <div class="flex justify-center space-x-2">
+            <button
+              class="px-3 py-1 w-36 font-bold font-size-5 color-black bg-#e9e2d3 rounded-full border-#735a3f b-2 hover:bg-#e9e2d3 hover:shadow-[inset_0_0_16px_rgba(255,255,255,1)] hover:border-white"
+              onClick={() => {
+                props.onCancel?.();
+              }}
+            >
+              取消
+            </button>
+            <button
+              class="px-3 py-1 w-36 font-bold font-size-5 color-black bg-#e9e2d3 rounded-full border-#735a3f b-2 hover:bg-#e9e2d3 hover:shadow-[inset_0_0_16px_rgba(255,255,255,1)] hover:border-white"
+              onClick={() => {
+                props.onConfirm();
+              }}
+            >
+              确认
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/web-ui-core/src/components/MessageBox.tsx
+++ b/packages/web-ui-core/src/components/MessageBox.tsx
@@ -13,60 +13,64 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { onMount } from "solid-js";
-import { render } from "solid-js/web";
+import { createSignal } from "solid-js";
 
-let dialogRef: HTMLDialogElement | null = null;
-let confirmCallback: () => void = () => {};
-let cancelCallback: () => void = () => {};
-let textEl: HTMLParagraphElement | null = null;
-
-export function messageBox(
-  question: string,
-  onConfirm: () => void,
-  onCancel?: () => void
-) {
-  confirmCallback = onConfirm;
-  cancelCallback = onCancel ?? (() => {});
-  if (textEl) textEl.textContent = question;
-  dialogRef?.showModal();
+export interface MessageBoxController {
+  confirm: (question: string) => Promise<boolean>;
 }
 
-export function mountMessageBox(target = document.body) {
-  const el = document.createElement("div");
-  target.appendChild(el);
-  render(() => <MessageBox />, el);
+export function createMessageBox() {
+  let dialogEl: HTMLDialogElement | undefined;
+  const [question, setQuestion] = createSignal<string>("");
+  let resolver: PromiseWithResolvers<boolean> | null = null;
+
+  return [
+    {
+      confirm: async (q) => {
+        setQuestion(q), (resolver = Promise.withResolvers<boolean>());
+        dialogEl?.showModal();
+        return await resolver.promise.finally(() => {
+          dialogEl?.close();
+        });
+      },
+    } as MessageBoxController,
+    () => (
+      <MessageBox
+        ref={dialogEl!}
+        question={question()}
+        onConfirm={() => resolver?.resolve(true)}
+        onCancel={() => resolver?.resolve(false)}
+      />
+    ),
+  ] as const;
 }
 
-function MessageBox() {
-  onMount(() => {});
+interface MessageBoxProps {
+  ref: HTMLDialogElement;
+  question: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function MessageBox(props: MessageBoxProps) {
   return (
     <dialog
-      ref={(el) => (dialogRef = el)}
+      ref={props.ref}
       class="bg-#ebdab7 p-4 rounded-3 shadow-lg w-96 h-48 border-#735a3f border-2"
     >
-      <p
-        class="h-24 font-size-6 font-bold mt-4 text-center"
-        ref={(el) => (textEl = el)}
-      >
-        message
+      <p class="h-24 font-size-6 font-bold mt-4 text-center">
+        {props.question}
       </p>
       <div class="flex justify-center gap-2">
         <button
           class="px-3 py-1 w-36 font-bold font-size-5 color-black bg-#e9e2d3 rounded-full border-#735a3f b-2 hover:bg-#e9e2d3 hover:shadow-[inset_0_0_16px_rgba(255,255,255,1)] hover:border-white"
-          onClick={() => {
-            dialogRef?.close();
-            cancelCallback();
-          }}
+          onClick={props.onCancel}
         >
           取消
         </button>
         <button
           class="px-3 py-1 w-36 font-bold font-size-5 color-black bg-#e9e2d3 rounded-full border-#735a3f b-2 hover:bg-#e9e2d3 hover:shadow-[inset_0_0_16px_rgba(255,255,255,1)] hover:border-white"
-          onClick={() => {
-            dialogRef?.close();
-            confirmCallback();
-          }}
+          onClick={props.onConfirm}
         >
           确定
         </button>


### PR DESCRIPTION
添加了可复用的MessageBox组件，可以用来响应对话框事件，支持传入参数message、onConfirm、onCancel
目前只用于放弃对局，解决移动端没有浏览器弹窗的问题

<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
